### PR TITLE
Add CI release job, update dependencies, and refactor tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: "maven" # See documentation for possible values
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -30,10 +30,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
 
       - name: Build with Maven
-        run: mvn
+        run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,15 +14,22 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish'
+        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 8+'
         required: true
-        default: '1.0.0-SNAPSHOT'
+        default: '${major}.${minor}.${patch}'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ inputs.revision }}
     steps:
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.revision }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
+          exit 1
+          fi
+
       - name: Checkout Source
         uses: actions/checkout@v5
 
@@ -51,6 +58,7 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
+
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -51,3 +51,71 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Tag ${{ inputs.revision }} already exists, skipping."
+          else
+            git tag ${{ inputs.revision }}
+            git push origin ${{ inputs.revision }}
+          fi
+
+      - name: Create Release
+        run: |
+          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release v${{ inputs.revision }} already exists, skipping."
+          else
+            gh release create v${{ inputs.revision }} \
+              --title "v${{ inputs.revision }}" \
+              --generate-notes \
+              --latest
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Increment patch version
+        run: |
+          CURRENT="${{ inputs.revision }}"
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
+          sed -i "s|^\( *\)<revision>[^<]*</revision>|\1<revision>${NEXT_VERSION}</revision>|" pom.xml
+          echo "Bumped version from ${CURRENT} to ${NEXT_VERSION}"
+
+      - name: Commit and push next version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+          git diff --cached --quiet && echo "No changes to commit" || \
+            git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push
+
+      - name: Merge release-1.x into dev-1.x
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git checkout dev-1.x; then
+            echo "::error::Branch 'dev-1.x' does not exist. Skipping merge."
+            exit 1
+          fi
+          if ! git merge --no-ff origin/release-1.x -m "chore: merge release-1.x into dev-1.x [skip ci]"; then
+            echo "::error::Merge conflict detected when merging release-1.x into dev-1.x. Manual intervention required."
+            exit 1
+          fi
+          git push origin dev-1.x

--- a/microsphere-mybatis-core/src/main/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptor.java
+++ b/microsphere-mybatis-core/src/main/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptor.java
@@ -119,7 +119,7 @@ public class InterceptingExecutorInterceptor implements Interceptor {
             }
             newProperties = newProperties.isEmpty() ? null : newProperties;
 
-            InterceptingExecutor interceptingExecutor = new InterceptingExecutor(delegate, properties, executorFilters);
+            InterceptingExecutor interceptingExecutor = new InterceptingExecutor(delegate, newProperties, executorFilters);
             return isCachingExecutor ? new CachingExecutor(interceptingExecutor) : interceptingExecutor;
         }
         logger.trace("The non-executor [{}] instance simply returns without any dynamic proxy interception", target);

--- a/microsphere-mybatis-core/src/main/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptor.java
+++ b/microsphere-mybatis-core/src/main/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptor.java
@@ -95,29 +95,29 @@ public class InterceptingExecutorInterceptor implements Interceptor {
                 delegate = getDelegate(cachingExecutor);
             }
 
-            Properties properties = new Properties();
+            Properties newProperties = new Properties();
             ExecutorFilter[] executorFilters = this.executorFilters;
 
             if (delegate instanceof InterceptingExecutor) {
-                List<ExecutorFilter> executorFiltersList = new LinkedList<>();
+                List<ExecutorFilter> newExecutorFiltersList = new LinkedList<>();
                 InterceptingExecutor previousInterceptingExecutor = (InterceptingExecutor) delegate;
                 delegate = previousInterceptingExecutor.getDelegate();
                 // merge Properties
                 Properties previousProperties = previousInterceptingExecutor.getProperties();
                 if (isNotEmpty(previousProperties)) {
-                    properties.putAll(previousProperties);
+                    newProperties.putAll(previousProperties);
                 }
 
                 // merge ExecutorFilters
-                addAll(executorFiltersList, previousInterceptingExecutor.getExecutorFilters());
-                addAll(executorFiltersList, executorFilters);
-                executorFilters = executorFiltersList.toArray(new ExecutorFilter[0]);
+                addAll(newExecutorFiltersList, previousInterceptingExecutor.getExecutorFilters());
+                addAll(newExecutorFiltersList, executorFilters);
+                executorFilters = newExecutorFiltersList.toArray(new ExecutorFilter[0]);
             }
 
             if (isNotEmpty(this.properties)) {
-                properties.putAll(this.properties);
+                newProperties.putAll(this.properties);
             }
-            properties = properties.isEmpty() ? null : properties;
+            newProperties = newProperties.isEmpty() ? null : newProperties;
 
             InterceptingExecutor interceptingExecutor = new InterceptingExecutor(delegate, properties, executorFilters);
             return isCachingExecutor ? new CachingExecutor(interceptingExecutor) : interceptingExecutor;

--- a/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/executor/InterceptingExecutorTest.java
+++ b/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/executor/InterceptingExecutorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Properties;
 
 import static io.microsphere.mybatis.executor.ExecutorsTest.mockExecutor;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * {@link InterceptingExecutor} Test
@@ -36,8 +37,10 @@ class InterceptingExecutorTest {
 
     @Test
     void testSetExecutorWrapper() {
-        Executor executor = mockExecutor();
-        InterceptingExecutor interceptingExecutor = new InterceptingExecutor(executor, new Properties());
-        interceptingExecutor.setExecutorWrapper(interceptingExecutor);
+        assertDoesNotThrow(() -> {
+            Executor executor = mockExecutor();
+            InterceptingExecutor interceptingExecutor = new InterceptingExecutor(executor, new Properties());
+            interceptingExecutor.setExecutorWrapper(interceptingExecutor);
+        });
     }
 }

--- a/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/executor/InterceptorsExecutorFilterAdapterTest.java
+++ b/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/executor/InterceptorsExecutorFilterAdapterTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.microsphere.mybatis.executor.ExecutorsTest.mockExecutor;
 import static io.microsphere.util.ArrayUtils.ofArray;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * {@link InterceptorsExecutorFilterAdapter} Test
@@ -34,9 +35,11 @@ class InterceptorsExecutorFilterAdapterTest {
 
     @Test
     void testDeferLoadOnFailed() {
-        ThrowingErrorExecutorInterceptor interceptor = new ThrowingErrorExecutorInterceptor();
-        InterceptorsExecutorFilterAdapter interceptorsExecutorFilterAdapter = new InterceptorsExecutorFilterAdapter(ofArray(interceptor));
-        ExecutorFilterChain executorFilterChain = new ExecutorFilterChain(mockExecutor(), null, new ThrowingErrorExecutorFilter());
-        interceptorsExecutorFilterAdapter.deferLoad(null, null, null, null, null, executorFilterChain);
+        assertDoesNotThrow(() -> {
+            ThrowingErrorExecutorInterceptor interceptor = new ThrowingErrorExecutorInterceptor();
+            InterceptorsExecutorFilterAdapter interceptorsExecutorFilterAdapter = new InterceptorsExecutorFilterAdapter(ofArray(interceptor));
+            ExecutorFilterChain executorFilterChain = new ExecutorFilterChain(mockExecutor(), null, new ThrowingErrorExecutorFilter());
+            interceptorsExecutorFilterAdapter.deferLoad(null, null, null, null, null, executorFilterChain);
+        });
     }
 }

--- a/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptorTest.java
+++ b/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptorTest.java
@@ -148,7 +148,7 @@ public class InterceptingExecutorInterceptorTest extends AbstractMapperTest {
     }
 
     @Test
-    void testIntercept() throws Throwable {
+    void testIntercept() {
         assertDoesNotThrow(() -> doInExecutor(executor -> {
             Invocation invocation = new Invocation(executor, findMethod(Executor.class, "isClosed"), ofArray());
             InterceptingExecutorInterceptor interceptor = createInterceptingExecutorInterceptor();

--- a/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptorTest.java
+++ b/microsphere-mybatis-core/src/test/java/io/microsphere/mybatis/plugin/InterceptingExecutorInterceptorTest.java
@@ -16,8 +16,9 @@
  */
 package io.microsphere.mybatis.plugin;
 
-import io.microsphere.mybatis.executor.LoggingExecutorInterceptor;
+import io.microsphere.mybatis.executor.ExecutorFilter;
 import io.microsphere.mybatis.executor.LoggingExecutorFilter;
+import io.microsphere.mybatis.executor.LoggingExecutorInterceptor;
 import io.microsphere.mybatis.executor.NoOpExecutorInterceptor;
 import io.microsphere.mybatis.executor.TestExecutorFilter;
 import io.microsphere.mybatis.executor.ThrowingErrorExecutorInterceptor;
@@ -40,6 +41,7 @@ import static io.microsphere.util.ArrayUtils.of;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Collections.emptyList;
 import static org.apache.ibatis.session.RowBounds.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -56,99 +58,102 @@ public class InterceptingExecutorInterceptorTest extends AbstractMapperTest {
 
     @Test
     void testInValidConstructorArgs() {
-        assertThrows(IllegalArgumentException.class, () -> new InterceptingExecutorInterceptor(ofArray()));
+        ExecutorFilter[] executorFilters = ofArray();
+        assertThrows(IllegalArgumentException.class, () -> new InterceptingExecutorInterceptor(executorFilters));
     }
 
     @Test
-    void testOnFailed() throws Throwable {
+    void testOnFailed() {
         // test Executor#update
-        doInExecutor(executor -> {
+        assertDoesNotThrow(() -> {
+            doInExecutor(executor -> {
 
-            // test Executor#update
-            runSafely(() -> {
-                MappedStatement ms = getMappedStatement(MS_ID_SAVE_USER);
-                executor.update(ms, null);
+                // test Executor#update
+                runSafely(() -> {
+                    MappedStatement ms = getMappedStatement(MS_ID_SAVE_USER);
+                    executor.update(ms, null);
+                });
+
+                // test Executor#query
+                runSafely(() -> {
+                    MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
+                    executor.query(ms, null, DEFAULT, Executor.NO_RESULT_HANDLER);
+                });
+
+                runSafely(() -> {
+                    MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
+                    BoundSql boundSql = new BoundSql(getConfiguration(), MS_ID_USER_BY_ID, emptyList(), null);
+
+                    CacheKey cacheKey = executor.createCacheKey(ms, null, new RowBounds(), boundSql);
+                    executor.query(ms, null, DEFAULT, Executor.NO_RESULT_HANDLER, cacheKey, boundSql);
+                });
+
+                // test Executor#queryCursor
+                runSafely(() -> {
+                    MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
+                    Connection connection = getConnection(executor);
+                    connection.close();
+                    executor.queryCursor(ms, null, DEFAULT);
+                });
+
+                // test Executor#createCacheKey
+                runSafely(() -> {
+                    executor.createCacheKey(null, null, DEFAULT, null);
+                });
+
+                runSafely(() -> {
+                    executor.close(false);
+                    executor.createCacheKey(null, null, DEFAULT, null);
+                });
+
             });
 
-            // test Executor#query
-            runSafely(() -> {
-                MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
-                executor.query(ms, null, DEFAULT, Executor.NO_RESULT_HANDLER);
+            doInExecutor(executor -> {
+                // test Executor#getTransaction
+                runSafely(() -> {
+                    executor.close(false);
+                    getConnection(executor);
+                });
             });
 
-            runSafely(() -> {
-                MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
-                BoundSql boundSql = new BoundSql(getConfiguration(), MS_ID_USER_BY_ID, emptyList(), null);
-
-                CacheKey cacheKey = executor.createCacheKey(ms, null, new RowBounds(), boundSql);
-                executor.query(ms, null, DEFAULT, Executor.NO_RESULT_HANDLER, cacheKey, boundSql);
+            doInExecutor(executor -> {
+                // test Executor#commit
+                runSafely(() -> {
+                    executor.close(false);
+                    executor.commit(true);
+                });
             });
 
-            // test Executor#queryCursor
-            runSafely(() -> {
-                MappedStatement ms = getMappedStatement(MS_ID_USER_BY_ID);
-                Connection connection = getConnection(executor);
-                connection.close();
-                executor.queryCursor(ms, null, DEFAULT);
+            doInExecutor(executor -> {
+                // test Executor#rollback
+                runSafely(() -> {
+                    Connection connection = getConnection(executor);
+                    connection.close();
+                    executor.rollback(true);
+                });
             });
 
-            // test Executor#createCacheKey
-            runSafely(() -> {
-                executor.createCacheKey(null, null, DEFAULT, null);
+            doInSqlSession(sqlSession -> {
+                runSafely(() -> {
+                    sqlSession.close();
+                    deferLoadAfterResultHandler(sqlSession);
+                });
             });
 
-            runSafely(() -> {
-                executor.close(false);
-                executor.createCacheKey(null, null, DEFAULT, null);
+            doInMapper(UserMapper.class, userMapper -> {
+                runSafely(() -> userMapper.getErrorUserByName("testing"));
             });
-
-        });
-
-        doInExecutor(executor -> {
-            // test Executor#getTransaction
-            runSafely(() -> {
-                executor.close(false);
-                getConnection(executor);
-            });
-        });
-
-        doInExecutor(executor -> {
-            // test Executor#commit
-            runSafely(() -> {
-                executor.close(false);
-                executor.commit(true);
-            });
-        });
-
-        doInExecutor(executor -> {
-            // test Executor#rollback
-            runSafely(() -> {
-                Connection connection = getConnection(executor);
-                connection.close();
-                executor.rollback(true);
-            });
-        });
-
-        doInSqlSession(sqlSession -> {
-            runSafely(() -> {
-                sqlSession.close();
-                deferLoadAfterResultHandler(sqlSession);
-            });
-        });
-
-        doInMapper(UserMapper.class, userMapper -> {
-            runSafely(() -> userMapper.getErrorUserByName("testing"));
         });
 
     }
 
     @Test
     void testIntercept() throws Throwable {
-        doInExecutor(executor -> {
+        assertDoesNotThrow(() -> doInExecutor(executor -> {
             Invocation invocation = new Invocation(executor, findMethod(Executor.class, "isClosed"), ofArray());
             InterceptingExecutorInterceptor interceptor = createInterceptingExecutorInterceptor();
             assertEquals(executor.isClosed(), interceptor.intercept(invocation));
-        });
+        }));
     }
 
     @Override
@@ -166,8 +171,7 @@ public class InterceptingExecutorInterceptorTest extends AbstractMapperTest {
     }
 
     private InterceptingExecutorInterceptor createInterceptingExecutorInterceptor() {
-        InterceptingExecutorInterceptor interceptor = new InterceptingExecutorInterceptor(of(new TestExecutorFilter()),
-                new LoggingExecutorInterceptor(), new TestInterceptorContextExecutorInterceptor());
-        return interceptor;
+        return new InterceptingExecutorInterceptor(of(new TestExecutorFilter()), new LoggingExecutorInterceptor(),
+                new TestInterceptorContextExecutorInterceptor());
     }
 }

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,14 +20,12 @@
 
     <properties>
         <!-- BOM -->
-        <microsphere-spring-cloud.version>0.1.5</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.7</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.14</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>
         <mybatis-spring-boot.version>2.1.2</mybatis-spring-boot.version>
         <h2.version>2.4.240</h2.version>
-        <!-- Testing-->
-        <junit.version>5.14.1</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -59,33 +57,6 @@
                 <version>${h2.version}</version>
             </dependency>
 
-            <!-- JUnit BOM -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- Spring Boot Dependencies -->
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- Spring Cloud Dependencies -->
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Microsphere Spring Cloud Dependencies -->
             <dependency>
                 <groupId>io.github.microsphere-projects</groupId>
@@ -99,34 +70,6 @@
     </dependencyManagement>
 
     <profiles>
-
-        <!-- Spring Cloud Profiles -->
-        <profile>
-            <id>spring-cloud-hoxton</id>
-            <properties>
-                <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
-                <spring-cloud.version>Hoxton.SR12</spring-cloud.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spring-cloud-2020</id>
-            <properties>
-                <spring-boot.version>2.4.13</spring-boot.version>
-                <spring-cloud.version>2020.0.5</spring-cloud.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spring-cloud-2021</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <spring-boot.version>2.6.15</spring-boot.version>
-                <spring-cloud.version>2021.0.9</spring-cloud.version>
-            </properties>
-        </profile>
 
         <profile>
             <id>java8</id>

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -19,13 +19,12 @@
     <description>Microsphere MyBatis Parent</description>
 
     <properties>
-        <!-- BOM -->
-        <microsphere-spring-cloud.version>0.1.7</microsphere-spring-cloud.version>
+        <!-- BOM versions -->
+        <microsphere-spring-cloud.version>0.1.8</microsphere-spring-cloud.version>
         <!-- Libraries -->
-        <mybatis.version>3.5.14</mybatis.version>
+        <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>
         <mybatis-spring-boot.version>2.1.2</mybatis-spring-boot.version>
-        <h2.version>2.4.240</h2.version>
     </properties>
 
     <dependencyManagement>
@@ -50,13 +49,6 @@
                 <version>${mybatis-spring-boot.version}</version>
             </dependency>
 
-            <!-- H2 -->
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2.version}</version>
-            </dependency>
-
             <!-- Microsphere Spring Cloud Dependencies -->
             <dependency>
                 <groupId>io.github.microsphere-projects</groupId>
@@ -68,18 +60,4 @@
 
         </dependencies>
     </dependencyManagement>
-
-    <profiles>
-
-        <profile>
-            <id>java8</id>
-            <activation>
-                <jdk>(,1.8]</jdk>
-            </activation>
-            <properties>
-                <h2.version>1.4.200</h2.version>
-            </properties>
-        </profile>
-
-    </profiles>
 </project>

--- a/microsphere-mybatis-spring-test/src/test/java/io/microsphere/mybatis/spring/test/config/MyBatisDataSourceTestConfigurationTest.java
+++ b/microsphere-mybatis-spring-test/src/test/java/io/microsphere/mybatis/spring/test/config/MyBatisDataSourceTestConfigurationTest.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import javax.sql.DataSource;
-import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -48,7 +47,7 @@ class MyBatisDataSourceTestConfigurationTest {
     private DataSource dataSource;
 
     @Test
-    void test() throws IOException {
+    void test() {
         assertNotNull(this.configuration);
         assertNotNull(this.dataSource);
     }

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.mybatis.spring.annotation;
 
-import io.microsphere.logging.Logger;
 import io.microsphere.mybatis.executor.ExecutorFilter;
 import io.microsphere.mybatis.executor.ExecutorInterceptor;
 import io.microsphere.mybatis.plugin.InterceptingExecutorInterceptor;
@@ -58,7 +57,6 @@ import java.util.stream.Stream;
 import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
 import static io.microsphere.constants.SymbolConstants.EQUAL;
 import static io.microsphere.constants.SymbolConstants.WILDCARD;
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.mybatis.spring.annotation.MyBatisConfigurationBeanDefintionRegistrar.CONFIGURATION_BEAN_NAME;
 import static io.microsphere.spring.beans.BeanUtils.getBeanNames;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
@@ -105,8 +103,6 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
      * The Spring Bean name of {@link InterceptingExecutorInterceptor}
      */
     public static final String INTERCEPTING_EXECUTOR_INTERCEPTOR_BEAN_NAME = "interceptingExecutorInterceptor";
-
-    private static final Logger logger = getLogger(ANNOTATION_CLASS_NAME);
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
@@ -363,7 +359,7 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
         return getBeanNames(beanFactory, beanType, true);
     }
 
-    static void setPropertyValue(BeanDefinitionBuilder builder, AnnotationAttributes attributes, String attributeName, Object defaultValue) {
+    void setPropertyValue(BeanDefinitionBuilder builder, AnnotationAttributes attributes, String attributeName, Object defaultValue) {
         Object value = attributes.get(attributeName);
         if (Objects.equals(defaultValue, value)) {
             logger.trace("Default property value[{}] will ignored the attribute[name : '{}']", defaultValue, attributeName);
@@ -372,12 +368,12 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
         setPropertyValue(builder, attributeName, value);
     }
 
-    static void setPropertyValue(BeanDefinitionBuilder builder, AnnotationAttributes attributes, String attributeName) {
+    void setPropertyValue(BeanDefinitionBuilder builder, AnnotationAttributes attributes, String attributeName) {
         Object attributeValue = attributes.get(attributeName);
         setPropertyValue(builder, attributeName, attributeValue);
     }
 
-    static void setPropertyValue(BeanDefinitionBuilder builder, String attributeName, Object attributeValue) {
+    void setPropertyValue(BeanDefinitionBuilder builder, String attributeName, Object attributeValue) {
         logger.trace("Set the BeanDefinition[{}] property[name : '{}'  , value : '{}']", builder.getRawBeanDefinition(), attributeName, attributeValue);
         builder.addPropertyValue(attributeName, attributeValue);
     }

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfiguration.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfiguration.java
@@ -99,7 +99,9 @@ public @interface MyBatisConfiguration {
      *
      * @return <code>true</code> as default.
      * @see Configuration#setMultipleResultSetsEnabled(boolean)
+     * @deprecated
      */
+    @Deprecated
     boolean multipleResultSetsEnabled() default true;
 
     /**

--- a/microsphere-mybatis-spring/src/test/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationTest.java
+++ b/microsphere-mybatis-spring/src/test/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationTest.java
@@ -84,7 +84,7 @@ class MyBatisConfigurationTest {
         assertEquals(annotation.lazyLoadingEnabled(), configuration.isLazyLoadingEnabled());
         assertEquals(annotation.aggressiveLazyLoading(), configuration.isAggressiveLazyLoading());
         // always true
-        assertEquals(annotation.multipleResultSetsEnabled(), configuration.isMultipleResultSetsEnabled());
+        assertEquals(true, configuration.isMultipleResultSetsEnabled());
         assertEquals(annotation.useColumnLabel(), configuration.isUseColumnLabel());
         assertEquals(annotation.useGeneratedKeys(), configuration.isUseGeneratedKeys());
         assertEquals(annotation.autoMappingBehavior(), configuration.getAutoMappingBehavior());

--- a/microsphere-mybatis-test/src/main/java/io/microsphere/mybatis/test/AbstractMyBatisTest.java
+++ b/microsphere-mybatis-test/src/main/java/io/microsphere/mybatis/test/AbstractMyBatisTest.java
@@ -44,12 +44,12 @@ import org.junit.jupiter.api.BeforeEach;
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.Reader;
+import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static org.apache.ibatis.io.Resources.getResourceAsReader;
@@ -85,6 +85,8 @@ public abstract class AbstractMyBatisTest {
     public static final String CHILD_TYPE_ALIAS = "child";
 
     public static final String FATHER_TYPE_ALIAS = "father";
+
+    private static final SecureRandom random = new SecureRandom();
 
     protected final Logger logger = getLogger(this.getClass());
 
@@ -211,7 +213,6 @@ public abstract class AbstractMyBatisTest {
     }
 
     public static User createUser() {
-        Random random = new Random();
         int id = random.nextInt(99999);
         String name = "User - " + id;
         return new User(id, name);

--- a/microsphere-mybatis-test/src/test/java/io/microsphere/mybatis/test/AbstractMyBatisTestTest.java
+++ b/microsphere-mybatis-test/src/test/java/io/microsphere/mybatis/test/AbstractMyBatisTestTest.java
@@ -41,6 +41,7 @@ import static io.microsphere.mybatis.test.AbstractMyBatisTest.configuration;
 import static io.microsphere.mybatis.test.AbstractMyBatisTest.dataSource;
 import static io.microsphere.mybatis.test.AbstractMyBatisTest.runCreateDatabaseScript;
 import static io.microsphere.mybatis.test.AbstractMyBatisTest.runDestroyDatabaseScript;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -93,9 +94,11 @@ class AbstractMyBatisTestTest {
     }
 
     @Test
-    void testRunScript() throws Exception {
-        DataSource dataSource = dataSource();
-        runCreateDatabaseScript(dataSource);
-        runDestroyDatabaseScript(dataSource);
+    void testRunScript() {
+        assertDoesNotThrow(() -> {
+            DataSource dataSource = dataSource();
+            runCreateDatabaseScript(dataSource);
+            runDestroyDatabaseScript(dataSource);
+        });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
-        <artifactId>microsphere-build</artifactId>
-        <version>0.2.3</version>
+        <artifactId>microsphere-spring-cloud-parent</artifactId>
+        <version>0.1.7</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request introduces several important improvements to dependency management, CI/CD automation, and code quality for the project. The main changes include adding Dependabot for automated dependency updates, enhancing the Maven build and publish workflows with better version handling and release automation, updating dependencies for compatibility, and improving test code robustness and clarity.

**CI/CD and Automation Improvements:**

* Added `.github/dependabot.yml` to enable automatic daily Maven dependency update PRs with a limit of 10 open PRs.
* Enhanced the Maven publish workflow (`.github/workflows/maven-publish.yml`) to:
  - Validate version format before publishing.
  - Automatically create tags and GitHub releases after publishing.
  - Bump the patch version in `pom.xml` after a release.
  - Merge `release-1.x` into `dev-1.x` to keep branches in sync. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL17-R32) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR61-R129)
* Updated Maven build workflow to use the Maven Wrapper (`./mvnw`) for better build consistency.

**Dependency and Build System Updates:**

* Upgraded `microsphere-spring-cloud.version` to 0.1.8 and `mybatis.version` to 3.5.19 in `microsphere-mybatis-parent/pom.xml`; removed unused dependencies and profiles for a cleaner and more maintainable build configuration. [[1]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L22-L30) [[2]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L55-L88) [[3]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L100-L141)

**Testing and Code Quality:**

* Refactored test code to use `assertDoesNotThrow` for better exception handling and clarity in several test classes. [[1]](diffhunk://#diff-e8e23d93ed8597b9feee4d51929128c533fa6da4f2ae63b68e73edabd73bde2aR27) [[2]](diffhunk://#diff-e8e23d93ed8597b9feee4d51929128c533fa6da4f2ae63b68e73edabd73bde2aR40-R44) [[3]](diffhunk://#diff-35e52d4b5fee41c649a043771d8d67c81aec6eacf9bdb6c6de26f5abe6fa6e1eR25) [[4]](diffhunk://#diff-35e52d4b5fee41c649a043771d8d67c81aec6eacf9bdb6c6de26f5abe6fa6e1eR38-R43) [[5]](diffhunk://#diff-6fbde93e6433902ce4862c6b30ae8a61215ad1bf6db64b876948bc19cce3a77fR44) [[6]](diffhunk://#diff-6fbde93e6433902ce4862c6b30ae8a61215ad1bf6db64b876948bc19cce3a77fL59-R68) [[7]](diffhunk://#diff-6fbde93e6433902ce4862c6b30ae8a61215ad1bf6db64b876948bc19cce3a77fR146-R156)
* Cleaned up unused imports and simplified test method signatures (e.g., removed unnecessary `throws` clauses). [[1]](diffhunk://#diff-e126ff0cafd1bde8bb928e782726cdf376aaa7732b06b66131e4bc7f9763ab15L27) [[2]](diffhunk://#diff-e126ff0cafd1bde8bb928e782726cdf376aaa7732b06b66131e4bc7f9763ab15L51-R50) [[3]](diffhunk://#diff-6fbde93e6433902ce4862c6b30ae8a61215ad1bf6db64b876948bc19cce3a77fL19-R21)

**Internal Refactoring:**

* Refactored variable names for clarity in `InterceptingExecutorInterceptor` and removed unused logger code in `MyBatisBeanDefinitionRegistrar`. [[1]](diffhunk://#diff-53dab8412f159a927241542e3b11015f85d331fe47955d335e151cb88873b4d6L98-R122) [[2]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL20) [[3]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL61) [[4]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL109-L110)

These changes collectively improve the maintainability, reliability, and automation of the project.