### PR TITLE
Fix Dependabot YAML structure and enhance maven-publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-- package-ecosystem: "maven" # See documentation for possible values
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 8+'
+        description: 'The version to publish for Spring Cloud Hoxton to 2021'
         required: true
         default: '${major}.${minor}.${patch}'
 
@@ -119,8 +119,9 @@ jobs:
           prompt = (
               f"Generate concise release notes for version {current_tag}.\n\n"
               f"Commits since {prev_tag}:\n{commits}\n\n"
-              "Format the output as markdown with sections for New Features, Bug Fixes, "
-              "and Other Changes (only include sections that have relevant commits). "
+              "Format the output as markdown with sections if present for New Features, Bug Fixes, "
+              "Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements "
+              "and Other Changes(excludes Full Changelog).\n\n"
               "Be concise and clear."
           )
 
@@ -153,20 +154,25 @@ jobs:
           if [ ! -f "$NOTES_FILE" ]; then
             printf "# Release Notes\n\n" > "$NOTES_FILE"
           fi
+          
+          FULL_CHANGELOG="**Full Changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREV_TAG...$CURRENT_TAG"
+          
           printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
-
+          printf "%s" "$FULL_CHANGELOG" >> "$NOTES_FILE"
+          
           # Write the current release notes to a temp file for the Create Release step
-          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s\n\n" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s" "$FULL_CHANGELOG" >> /tmp/current-release-notes.md
 
           echo "Release notes generated and appended to $NOTES_FILE"
 
       - name: Create Release
         run: |
-          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
-            echo "Release v${{ inputs.revision }} already exists, skipping."
+          if gh release view "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release ${{ inputs.revision }} already exists, skipping."
           else
             gh release create ${{ inputs.revision }} \
-              --title "v${{ inputs.revision }}" \
+              --title "${{ inputs.revision }}" \
               --notes-file /tmp/current-release-notes.md \
               --latest
           fi

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.3              |
-| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.3              |
+| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.4              |
+| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.4              |
 
 Then add the specific modules you need.
 

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.10</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.11</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
@@ -18,6 +18,7 @@
 package io.microsphere.mybatis.spring.annotation;
 
 import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.AnnotationUtils;
 import org.apache.ibatis.session.Configuration;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -31,7 +32,6 @@ import java.util.Map.Entry;
 import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.mybatis.spring.annotation.MyBatisBeanDefinitionRegistrar.stringArrayToProperties;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static io.microsphere.util.ClassLoaderUtils.loadClass;
 import static io.microsphere.util.ClassUtils.newInstance;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
@@ -68,7 +68,7 @@ public class MyBatisConfigurationBeanDefintionRegistrar extends BeanCapableImpor
         Class<?> targetClass = loadClass(classLoader, className);
         MyBatisConfiguration annotation = targetClass.getAnnotation(ANNOTATION_CLASS);
         // Only concerns the non-default attributes
-        AnnotationAttributes annotationAttributes = getAnnotationAttributes(annotation, getEnvironment(), true);
+        AnnotationAttributes annotationAttributes = AnnotationUtils.getAnnotationAttributes(annotation, getEnvironment(), true);
 
         BeanDefinitionBuilder builder = genericBeanDefinition(Configuration.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates dependencies, improves release note generation, and makes a minor code import correction. The most important changes are summarized below:

**Dependency and Version Updates:**

* Updated `microsphere-spring-cloud.version` property in `microsphere-mybatis-parent/pom.xml` from `0.1.10` to `0.1.11`.
* Updated the parent version in `pom.xml` from `0.1.10` to `0.1.11`.
* Updated the "Latest Version" numbers for both `0.2.x` and `0.1.x` branches in the version table in `README.md`.

**Release Notes and Workflow Enhancements:**

* Improved the release notes generation in `.github/workflows/maven-publish.yml`:
  - Expanded the section list in the release notes to include "Documentations", "Dependency Updates", "Test Improvements", and "Build and Workflow Enhancements".
  - Added a "Full Changelog" link to the release notes output. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL122-R124) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR157-R175)
* Clarified the `revision` input description in the workflow to specify "Spring Cloud Hoxton to 2021".

**Code Import and Refactor:**

* Replaced a static import of `getAnnotationAttributes` with a direct import of `AnnotationUtils` and updated its usage in `MyBatisConfigurationBeanDefintionRegistrar.java` for clarity and maintainability. [[1]](diffhunk://#diff-083d3083daae202313af4d7ae160eeea3e6ce3b0c225c3435cc288ac6eac1fc9R21) [[2]](diffhunk://#diff-083d3083daae202313af4d7ae160eeea3e6ce3b0c225c3435cc288ac6eac1fc9L34) [[3]](diffhunk://#diff-083d3083daae202313af4d7ae160eeea3e6ce3b0c225c3435cc288ac6eac1fc9L71-R71)