### PR TITLE
Update microsphere-spring-cloud to 0.1.15 and consolidate bean registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.7`            |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.7`            |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.8`            |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.8`            |
 
 Then add the specific modules you need.
 

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.14</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
@@ -50,6 +50,7 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 
 import javax.sql.DataSource;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -61,9 +62,9 @@ import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
 import static io.microsphere.constants.SymbolConstants.EQUAL;
 import static io.microsphere.constants.SymbolConstants.WILDCARD;
 import static io.microsphere.mybatis.spring.annotation.MyBatisConfigurationBeanDefintionRegistrar.CONFIGURATION_BEAN_NAME;
+import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.BeanUtils.getBeanNames;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerSpringFactoriesBeans;
 import static io.microsphere.spring.core.env.PropertySourcesUtils.getPropertyNames;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ArrayUtils.arrayToString;
@@ -187,17 +188,8 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
      * @param sources  the array of {@link BeanSource}s indicating where to look for bean implementations
      */
     private void registerBeansFromSources(BeanDefinitionRegistry registry, Class<?> beanType, BeanSource[] sources) {
-        for (BeanSource source : sources) {
-            switch (source) {
-                case SPRING_FACTORIES:
-                    registerSpringFactoriesBeans(registry, beanType);
-                case JAVA_SERVICE_PROVIDER:
-                    registerJavaServiceProviderBeans(registry, beanType);
-                case BEAN_FACTORY:
-                default:
-                    // Do nothing, the beans of ExecutorFilter or ExecutorInterceptor should be registered by users manually.
-            }
-        }
+        Map<Class<?>, String> beanTypesAndNames = registerBeans(this.beanFactory, sources, beanType);
+        logger.trace("Registered {} implementation(s) from the sources : {} : {}", beanType, sources, beanTypesAndNames);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates dependencies and refactors bean registration logic to improve maintainability and consistency across the project. The main changes include updating version numbers, refactoring the way beans are registered from different sources, and cleaning up imports.

**Dependency and Version Updates:**
- Updated `microsphere-spring-cloud` dependency version from `0.1.14` to `0.1.15` in `pom.xml` and `microsphere-mybatis-parent/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L23-R23)
- Updated documented latest versions for the `main` and `1.x` branches in `README.md`.

**Bean Registration Refactor:**
- Refactored `registerBeansFromSources` in `MyBatisBeanDefinitionRegistrar` to use the unified `registerBeans` method, replacing the previous switch-case logic and removing the direct call to `registerSpringFactoriesBeans`. This improves modularity and reduces duplication.
- Added import for `registerBeans` and removed the unused import for `registerSpringFactoriesBeans` in `MyBatisBeanDefinitionRegistrar.java`.

**General Code Cleanup:**
- Added missing import for `Map` in `MyBatisBeanDefinitionRegistrar.java`.