### PR TITLE
Refactor executor bean registration and update parent version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.8`            |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.8`            |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.9`            |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.9`            |
 
 Then add the specific modules you need.
 

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.16</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
@@ -53,8 +53,6 @@ import javax.sql.DataSource;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 
@@ -71,7 +69,6 @@ import static io.microsphere.util.ArrayUtils.arrayToString;
 import static io.microsphere.util.ArrayUtils.forEach;
 import static io.microsphere.util.ArrayUtils.length;
 import static io.microsphere.util.Assert.assertTrue;
-import static io.microsphere.util.ServiceLoaderUtils.getServiceClasses;
 import static io.microsphere.util.StringUtils.isBlank;
 import static io.microsphere.util.StringUtils.split;
 import static io.microsphere.util.StringUtils.trimAllWhitespace;
@@ -103,8 +100,6 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ge
  * @since 1.0.0
  */
 public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
-
-    static final Class<EnableMyBatis> ANNOTATION_CLASS = EnableMyBatis.class;
 
     /**
      * The Spring Bean name of {@link SqlSessionFactory}
@@ -150,8 +145,8 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
                                                             BeanDefinitionRegistry registry) {
         if (attributes.getBoolean("interceptExecutor")) {
             BeanSource[] sources = (BeanSource[]) attributes.get("sources");
-            registerExecutorFilters(registry, sources);
-            registerExecutorInterceptors(registry, sources);
+            registerExecutorFilters(sources);
+            registerExecutorInterceptors(sources);
             registerInterceptingExecutorInterceptorIfRequired(registry);
         }
     }
@@ -159,21 +154,19 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
     /**
      * Registers {@link ExecutorFilter} beans from the specified {@link BeanSource}s.
      *
-     * @param registry the {@link BeanDefinitionRegistry} to register bean definitions with
-     * @param sources  the array of {@link BeanSource}s to scan for {@link ExecutorFilter} implementations
+     * @param sources the array of {@link BeanSource}s to scan for {@link ExecutorFilter} implementations
      */
-    private void registerExecutorFilters(BeanDefinitionRegistry registry, BeanSource[] sources) {
-        registerBeansFromSources(registry, ExecutorFilter.class, sources);
+    private void registerExecutorFilters(BeanSource[] sources) {
+        registerBeansFromSources(ExecutorFilter.class, sources);
     }
 
     /**
      * Registers {@link ExecutorInterceptor} beans from the specified {@link BeanSource}s.
      *
-     * @param registry the {@link BeanDefinitionRegistry} to register bean definitions with
-     * @param sources  the array of {@link BeanSource}s to scan for {@link ExecutorInterceptor} implementations
+     * @param sources the array of {@link BeanSource}s to scan for {@link ExecutorInterceptor} implementations
      */
-    private void registerExecutorInterceptors(BeanDefinitionRegistry registry, BeanSource[] sources) {
-        registerBeansFromSources(registry, ExecutorInterceptor.class, sources);
+    private void registerExecutorInterceptors(BeanSource[] sources) {
+        registerBeansFromSources(ExecutorInterceptor.class, sources);
     }
 
     /**
@@ -183,29 +176,12 @@ public class MyBatisBeanDefinitionRegistrar extends BeanCapableImportCandidate i
      * Java Service Provider Interface (SPI), or expect them to be manually registered
      * in the Bean Factory.
      *
-     * @param registry the {@link BeanDefinitionRegistry} to register bean definitions with
      * @param beanType the type of beans to register
      * @param sources  the array of {@link BeanSource}s indicating where to look for bean implementations
      */
-    private void registerBeansFromSources(BeanDefinitionRegistry registry, Class<?> beanType, BeanSource[] sources) {
+    private void registerBeansFromSources(Class<?> beanType, BeanSource[] sources) {
         Map<Class<?>, String> beanTypesAndNames = registerBeans(this.beanFactory, sources, beanType);
         logger.trace("Registered {} implementation(s) from the sources : {} : {}", beanType, sources, beanTypesAndNames);
-    }
-
-    /**
-     * Registers beans of the specified type discovered via the Java Service Provider Interface (SPI).
-     * <p>
-     * This method uses {@link ServiceLoader} to find implementations of the given {@code beanType}
-     * and registers each discovered class as a bean definition in the registry.
-     *
-     * @param registry the {@link BeanDefinitionRegistry} to register bean definitions with
-     * @param beanType the interface or abstract class whose implementations are to be discovered and registered
-     */
-    private void registerJavaServiceProviderBeans(BeanDefinitionRegistry registry, Class<?> beanType) {
-        Set<? extends Class<?>> serviceClasses = getServiceClasses(beanType, this.classLoader);
-        for (Class<?> serviceClass : serviceClasses) {
-            registerBeanDefinition(registry, serviceClass);
-        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.16</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request primarily updates dependency versions and refactors the `MyBatisBeanDefinitionRegistrar` class to simplify bean registration logic. The most significant changes are the removal of unused imports and methods related to Java Service Provider Interface (SPI) registration, and the streamlining of method signatures for registering beans.

Dependency and version updates:
* Updated the `microsphere-spring-cloud` dependency version from `0.1.15` to `0.1.16` in both `pom.xml` and `microsphere-mybatis-parent/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L23-R23)
* Updated the documented latest versions for the `main` and `1.x` branches in `README.md` to `0.2.9` and `0.1.9` respectively.

Codebase simplification and cleanup:
* Removed unused imports and the `registerJavaServiceProviderBeans` method from `MyBatisBeanDefinitionRegistrar`, eliminating SPI-based bean registration logic. [[1]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL56-L57) [[2]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL74) [[3]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL186-L210)
* Simplified method signatures for `registerExecutorFilters`, `registerExecutorInterceptors`, and `registerBeansFromSources` by removing the `BeanDefinitionRegistry` parameter, as it is no longer needed. [[1]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL153-R169) [[2]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL186-L210)
* Minor code cleanup, such as removing an unused static field.