### PR TITLE
Update microsphere-spring-cloud to 0.1.21 and refactor MyBatis config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.10`           |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.10`           |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.11`           |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.11`           |
 
 Then add the specific modules you need.
 

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.16</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.21</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>

--- a/microsphere-mybatis-spring-boot/src/main/java/io/microsphere/mybatis/spring/boot/autoconfigure/condition/ConditionalOnMyBatisAvailable.java
+++ b/microsphere-mybatis-spring-boot/src/main/java/io/microsphere/mybatis/spring/boot/autoconfigure/condition/ConditionalOnMyBatisAvailable.java
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  *
  * @see ConditionalOnMyBatisEnabled
- * @see ConditionalOnClass
+ * @see org.springframework.boot.autoconfigure.condition.ConditionalOnClass
  */
 @Target(TYPE)
 @Retention(RUNTIME)

--- a/microsphere-mybatis-spring-cloud/src/main/java/io/microsphere/mybatis/spring/cloud/autoconfigure/MyBatisCloudAutoConfiguration.java
+++ b/microsphere-mybatis-spring-cloud/src/main/java/io/microsphere/mybatis/spring/cloud/autoconfigure/MyBatisCloudAutoConfiguration.java
@@ -17,30 +17,9 @@
 
 package io.microsphere.mybatis.spring.cloud.autoconfigure;
 
-import io.microsphere.mybatis.executor.ExecutorFilter;
-import io.microsphere.mybatis.executor.ExecutorInterceptor;
 import io.microsphere.mybatis.spring.boot.autoconfigure.condition.ConditionalOnMyBatisEnabled;
-import io.microsphere.spring.cloud.client.condition.ConditionalOnFeaturesEnabled;
-import org.apache.ibatis.session.SqlSessionFactory;
-import org.mybatis.spring.SqlSessionFactoryBean;
-import org.mybatis.spring.SqlSessionTemplate;
-import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.cloud.client.actuator.HasFeatures;
-import org.springframework.cloud.client.actuator.NamedFeature;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-
-import java.util.List;
-import java.util.Set;
-
-import static io.microsphere.collection.ListUtils.newArrayList;
-import static io.microsphere.collection.SetUtils.of;
-import static io.microsphere.constants.SymbolConstants.DOT;
-import static io.microsphere.mybatis.constants.PropertyConstants.MICROSPHERE_MYBATIS_PROPERTY_NAME_PREFIX;
-import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
-import static java.util.Collections.emptyList;
 
 /**
  * The Auto-{@link Configuration} for MyBatis Spring Cloud
@@ -64,62 +43,5 @@ import static java.util.Collections.emptyList;
 @AutoConfigureAfter(name = {
         "org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration"
 })
-@Import(MyBatisCloudAutoConfiguration.FeaturesConfiguration.class)
 public class MyBatisCloudAutoConfiguration {
-
-    /**
-     * Inner {@link Configuration} that registers the {@link HasFeatures} bean when
-     * Spring Cloud features reporting is enabled.
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     *   // When @ConditionalOnFeaturesEnabled is satisfied, the "myBatisFeatures" bean is
-     *   // automatically created and exposed to the Spring Cloud actuator feature endpoint.
-     * }</pre>
-     */
-    @ConditionalOnFeaturesEnabled
-    public static class FeaturesConfiguration {
-
-        /**
-         * The bean name of {@link HasFeatures}
-         *
-         * @see #mybatisFeatures(ListableBeanFactory)
-         */
-        public final static String MYBATIS_FEATURES_BEAN_NAME = "myBatisFeatures";
-
-        private static Set<Class<?>> typeFeatures = of(
-                org.apache.ibatis.session.Configuration.class,
-                SqlSessionFactory.class,
-                SqlSessionFactoryBean.class,
-                SqlSessionTemplate.class,
-                ExecutorFilter.class,
-                ExecutorInterceptor.class
-        );
-
-        /**
-         * Create a {@link HasFeatures} bean that exposes the active MyBatis components as named features
-         * for the Spring Cloud actuator features endpoint.
-         *
-         * <h3>Example Usage</h3>
-         * <pre>{@code
-         *   // Accessed via the Spring Cloud actuator features endpoint at /actuator/features.
-         *   // Each present bean type is reported as a named feature:
-         *   //   "microsphere.mybatis.SqlSessionFactory" -> SqlSessionFactory.class
-         * }</pre>
-         *
-         * @param beanFactory the {@link ListableBeanFactory} used to check which beans are present
-         * @return a {@link HasFeatures} with one {@link NamedFeature} per present MyBatis component type
-         */
-        @Bean(name = MYBATIS_FEATURES_BEAN_NAME)
-        public HasFeatures mybatisFeatures(ListableBeanFactory beanFactory) {
-            List<NamedFeature> namedFeatures = newArrayList(typeFeatures.size());
-            for (Class<?> type : typeFeatures) {
-                if (isBeanPresent(beanFactory, type)) {
-                    String name = MICROSPHERE_MYBATIS_PROPERTY_NAME_PREFIX + DOT + type.getSimpleName();
-                    namedFeatures.add(new NamedFeature(name, type));
-                }
-            }
-            return new HasFeatures(emptyList(), namedFeatures);
-        }
-    }
 }

--- a/microsphere-mybatis-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-mybatis-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
@@ -1,0 +1,42 @@
+microsphere:
+  spring:
+    cloud:
+      features:
+        abstract:
+          mybatis:
+            - org.apache.ibatis.executor.Executor
+            - org.apache.ibatis.plugin.Interceptor
+            - org.apache.ibatis.type.TypeHandler
+            - org.apache.ibatis.scripting.LanguageDriver
+            - org.apache.ibatis.mapping.DatabaseIdProvider
+            - org.apache.ibatis.datasource.DataSourceFactory
+            - org.apache.ibatis.session.SqlSessionFactory
+            - org.apache.ibatis.transaction.TransactionFactory
+            - org.apache.ibatis.session.Configuration
+            - org.apache.ibatis.cache.Cache
+            - org.apache.ibatis.executor.keygen.KeyGenerator
+            - org.apache.ibatis.executor.loader.ProxyFactory
+            - org.apache.ibatis.executor.parameter.ParameterHandler
+            - org.apache.ibatis.session.ResultContext
+            - org.apache.ibatis.executor.resultset.ResultSetHandler
+            - org.apache.ibatis.executor.statement.StatementHandler
+            - org.apache.ibatis.session.ResultHandler
+            - org.apache.ibatis.mapping.SqlSource
+            - org.apache.ibatis.reflection.ReflectorFactory
+          mybatis-spring:
+            - org.mybatis.spring.SqlSessionTemplate
+            - org.mybatis.spring.mapper.MapperFactoryBean
+            - org.mybatis.spring.mapper.MapperScannerConfigurer
+            - org.mybatis.spring.config.MapperScannerBeanDefinitionParser
+            - org.mybatis.spring.SqlSessionFactoryBean
+            - org.mybatis.spring.transaction.SpringManagedTransactionFactory
+          mybatis-spring-boot-autoconfigure:
+            - org.mybatis.spring.boot.autoconfigure.MybatisProperties
+            - org.mybatis.spring.boot.autoconfigure.ConfigurationCustomizer
+            - org.mybatis.spring.boot.autoconfigure.SqlSessionFactoryBeanCustomizer
+          microsphere-mybatis-core:
+            - io.microsphere.mybatis.executor.ExecutorFilter
+            - io.microsphere.mybatis.executor.ExecutorInterceptor
+        named:
+          microsphere-mybatis-spring-boot:
+            - ConditionalOnMyBatisAvailable: io.microsphere.mybatis.spring.boot.autoconfigure.condition.ConditionalOnMyBatisAvailable

--- a/microsphere-mybatis-spring-cloud/src/test/java/io/microsphere/mybatis/spring/cloud/autoconfigure/MyBatisCloudAutoConfigurationTest.java
+++ b/microsphere-mybatis-spring-cloud/src/test/java/io/microsphere/mybatis/spring/cloud/autoconfigure/MyBatisCloudAutoConfigurationTest.java
@@ -17,18 +17,23 @@
 
 package io.microsphere.mybatis.spring.cloud.autoconfigure;
 
+import io.microsphere.mybatis.executor.LoggingExecutorFilter;
+import io.microsphere.mybatis.executor.LoggingExecutorInterceptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.actuator.FeaturesEndpoint;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.actuator.NamedFeature;
 
 import java.util.List;
+import java.util.Map;
 
-import static io.microsphere.mybatis.spring.cloud.autoconfigure.MyBatisCloudAutoConfiguration.FeaturesConfiguration.MYBATIS_FEATURES_BEAN_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 /**
  * {@link MyBatisCloudAutoConfiguration} Test
@@ -38,18 +43,45 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 1.0.0
  */
 @SpringBootTest(classes = {
+        LoggingExecutorFilter.class,
+        LoggingExecutorInterceptor.class,
         MyBatisCloudAutoConfigurationTest.class
-})
+}, webEnvironment = NONE,
+        properties = {
+                "spring.cloud.features.enabled=true",
+                "management.endpoints.web.exposure.include=*",
+        }
+)
 @EnableAutoConfiguration
 class MyBatisCloudAutoConfigurationTest {
 
     @Autowired
-    @Qualifier(MYBATIS_FEATURES_BEAN_NAME)
-    private HasFeatures hasFeatures;
+    private Map<String, HasFeatures> hasFeaturesMap;
+
+    @Autowired
+    private FeaturesEndpoint featuresEndpoint;
 
     @Test
-    void test() {
-        List<NamedFeature> namedFeatures = hasFeatures.getNamedFeatures();
-        assertEquals(2, namedFeatures.size());
+    public void test() {
+        assertTrue(this.hasFeaturesMap.size() > 0);
+        HasFeatures hadFeatures = this.hasFeaturesMap.get("mybatis.features");
+        assertNotNull(hadFeatures);
+
+        hadFeatures = this.hasFeaturesMap.get("mybatis-spring.features");
+        assertNotNull(hadFeatures);
+
+        hadFeatures = this.hasFeaturesMap.get("mybatis-spring-boot-autoconfigure.features");
+        assertNotNull(hadFeatures);
+
+        hadFeatures = this.hasFeaturesMap.get("microsphere-mybatis-core.features");
+        assertNotNull(hadFeatures);
+
+        assertNotNull(featuresEndpoint.features());
+    }
+
+    private void assertNamedFeature(List<NamedFeature> namedFeatures, int index, String name, Class<?> type) {
+        NamedFeature namedFeature = namedFeatures.get(index);
+        assertEquals(name, namedFeature.getName());
+        assertEquals(type, namedFeature.getType());
     }
 }

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
@@ -31,8 +31,6 @@ import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -45,24 +43,13 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 
 import javax.sql.DataSource;
-import java.util.Objects;
 import java.util.Properties;
-import java.util.StringJoiner;
-import java.util.stream.Stream;
 
-import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
-import static io.microsphere.constants.SymbolConstants.EQUAL;
-import static io.microsphere.constants.SymbolConstants.WILDCARD;
 import static io.microsphere.mybatis.spring.annotation.MyBatisConfigurationBeanDefintionRegistrar.CONFIGURATION_BEAN_NAME;
-import static io.microsphere.spring.beans.BeanUtils.getBeanNames;
 import static io.microsphere.spring.core.env.PropertySourcesUtils.getPropertyNames;
 import static io.microsphere.text.FormatUtils.format;
-import static io.microsphere.util.ArrayUtils.arrayToString;
-import static io.microsphere.util.ArrayUtils.length;
 import static io.microsphere.util.Assert.assertTrue;
 import static io.microsphere.util.StringUtils.isBlank;
-import static io.microsphere.util.StringUtils.split;
-import static io.microsphere.util.StringUtils.trimAllWhitespace;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 /**

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisBeanDefinitionRegistrar.java
@@ -18,6 +18,7 @@
 package io.microsphere.mybatis.spring.annotation;
 
 import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.io.VFS;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
@@ -33,6 +34,7 @@ import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -89,13 +91,15 @@ public class MyBatisBeanDefinitionRegistrar extends MyBatisImportBeanDefinitionR
     public static final String SQL_SESSION_TEMPLATE_BEAN_NAME = "sqlSessionTemplate";
 
     @Override
-    protected void registerBeanDefinitions(AnnotationAttributes attributes, AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableMyBatis> annotationAttributes) {
 
         // Register the BeanDefinition of SqlSessionFactoryBean if absent
-        registerSqlSessionFactoryBeanIfAbsent(attributes, registry);
+        registerSqlSessionFactoryBeanIfAbsent(annotationAttributes, registry);
 
         // Register the BeanDefinition of SqlSessionTemplate if absent
-        registerSqlSessionTemplateIfAbsent(attributes, registry);
+        registerSqlSessionTemplateIfAbsent(annotationAttributes, registry);
     }
 
     /**
@@ -239,4 +243,5 @@ public class MyBatisBeanDefinitionRegistrar extends MyBatisImportBeanDefinitionR
         properties.putAll(stringArrayToProperties(configurationProperties));
         return properties;
     }
+
 }

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
@@ -18,7 +18,6 @@
 package io.microsphere.mybatis.spring.annotation;
 
 import io.microsphere.spring.core.annotation.AnnotationUtils;
-import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.apache.ibatis.session.Configuration;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
-import java.lang.annotation.Annotation;
 import java.util.Map.Entry;
 
 import static io.microsphere.collection.Sets.ofSet;

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisConfigurationBeanDefintionRegistrar.java
@@ -18,17 +18,21 @@
 package io.microsphere.mybatis.spring.annotation;
 
 import io.microsphere.spring.core.annotation.AnnotationUtils;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.apache.ibatis.session.Configuration;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.Map.Entry;
 
 import static io.microsphere.collection.Sets.ofSet;
+import static io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes.of;
 import static io.microsphere.util.ClassLoaderUtils.resolveClass;
 import static io.microsphere.util.ClassUtils.newInstance;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
@@ -67,12 +71,21 @@ class MyBatisConfigurationBeanDefintionRegistrar extends MyBatisImportBeanDefini
     public static final String CONFIGURATION_BEAN_NAME = "configuration";
 
     @Override
-    protected void registerBeanDefinitions(AnnotationAttributes attributes, AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        String configClassName = metadata.getClassName();
-        Class<?> configClass = resolveClass(configClassName, super.classLoader);
-        MyBatisConfiguration myBatisConfiguration = configClass.getAnnotation(super.annotationType);
-        AnnotationAttributes annotationAttributes = AnnotationUtils.getAnnotationAttributes(myBatisConfiguration, super.environment, true);
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<MyBatisConfiguration> annotationAttributes) {
         registerConfigurationIfAbsent(annotationAttributes, registry);
+    }
+
+    @Override
+    protected ResolvablePlaceholderAnnotationAttributes<MyBatisConfiguration> getAnnotationAttributes(AnnotationMetadata metadata) {
+        String configClassName = metadata.getClassName();
+        Class<?> configClass = resolveClass(configClassName, getClassLoader());
+        Class<MyBatisConfiguration> annotationType = getAnnotationType();
+        ConfigurableEnvironment environment = getEnvironment();
+        MyBatisConfiguration myBatisConfiguration = configClass.getAnnotation(annotationType);
+        AnnotationAttributes annotationAttributes = AnnotationUtils.getAnnotationAttributes(myBatisConfiguration, environment, true);
+        return of(annotationAttributes, annotationType, environment);
     }
 
     private void registerConfigurationIfAbsent(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
@@ -102,4 +115,5 @@ class MyBatisConfigurationBeanDefintionRegistrar extends MyBatisImportBeanDefini
         }
         return builder.getBeanDefinition();
     }
+
 }

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisExtensionBeanDefinitionRegistrar.java
@@ -23,9 +23,11 @@ import io.microsphere.mybatis.executor.ExecutorInterceptor;
 import io.microsphere.mybatis.executor.InterceptingExecutor;
 import io.microsphere.mybatis.plugin.InterceptingExecutorInterceptor;
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -67,12 +69,15 @@ public class MyBatisExtensionBeanDefinitionRegistrar extends MyBatisImportBeanDe
      * from the specified sources, and conditionally registering the
      * {@link InterceptingExecutorInterceptor} if any filters or interceptors are present.
      *
-     * @param attributes the resolved {@link AnnotationAttributes} from {@link EnableMyBatisExtension}
-     * @param metadata   the {@link AnnotationMetadata} of the importing class
-     * @param registry   the {@link BeanDefinitionRegistry} to register bean definitions with
+     * @param metadata                the {@link AnnotationMetadata} of the importing class
+     * @param registry                the {@link BeanDefinitionRegistry} to register bean definitions into
+     * @param importBeanNameGenerator the {@link BeanNameGenerator} to use for generating bean names
+     * @param attributes              the resolved {@link AnnotationAttributes} from {@link EnableMyBatisExtension}
      */
     @Override
-    protected void registerBeanDefinitions(AnnotationAttributes attributes, AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableMyBatisExtension> attributes) {
         if (attributes.getBoolean("interceptExecutor")) {
             BeanSource[] sources = (BeanSource[]) attributes.get("sources");
             registerExecutorFilters(sources);

--- a/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisImportBeanDefinitionRegistrar.java
+++ b/microsphere-mybatis-spring/src/main/java/io/microsphere/mybatis/spring/annotation/MyBatisImportBeanDefinitionRegistrar.java
@@ -17,7 +17,7 @@
 
 package io.microsphere.mybatis.spring.annotation;
 
-import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.core.type.AnnotationMetadata;
 
 import java.lang.annotation.Annotation;
 import java.util.Objects;
@@ -55,27 +54,8 @@ import static org.springframework.core.ResolvableType.forType;
  * @see ImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-abstract class MyBatisImportBeanDefinitionRegistrar<A extends Annotation> extends BeanCapableImportCandidate
+abstract class MyBatisImportBeanDefinitionRegistrar<A extends Annotation> extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<A>
         implements ImportBeanDefinitionRegistrar {
-
-    protected final Class<A> annotationType;
-
-    MyBatisImportBeanDefinitionRegistrar() {
-        this.annotationType = (Class<A>) forType(this.getClass())
-                .as(MyBatisImportBeanDefinitionRegistrar.class)
-                .getGeneric(0)
-                .resolve();
-    }
-
-    @Override
-    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes attributes = getAnnotationAttributes(metadata, this.annotationType);
-        registerBeanDefinitions(attributes, metadata, registry);
-    }
-
-    protected abstract void registerBeanDefinitions(AnnotationAttributes attributes, AnnotationMetadata metadata,
-                                                    BeanDefinitionRegistry registry);
-
 
     protected void registerBeanDefinitionIfAbsent(AnnotationAttributes attributes, BeanDefinitionRegistry registry,
                                                   String beanName,

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.16</version>
+        <version>0.1.21</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request introduces several significant changes to the Microsphere MyBatis project, primarily focused on upgrading dependencies, refactoring the Spring Cloud auto-configuration for MyBatis, and enhancing feature exposure for actuator endpoints. The changes include updating parent and BOM versions, removing legacy feature-reporting code, introducing a YAML-based feature definition, and updating related tests and documentation.

**Dependency Upgrades:**
- Upgraded the parent POM and the `microsphere-spring-cloud` BOM version from `0.1.16` to `0.1.21` in both the root `pom.xml` and `microsphere-mybatis-parent/pom.xml` for improved compatibility and new features. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-1e0b6f618cc2b253823f0d233a89680a59b313b9113c574b5ebf4a8c42d8cdc6L23-R23)

**Spring Cloud Features Refactoring:**
- Removed the inner `FeaturesConfiguration` class and related feature-reporting beans from `MyBatisCloudAutoConfiguration`, shifting feature exposure to a new configuration approach. [[1]](diffhunk://#diff-e69c32266211b6533ac5a54c04bda80f9cd3bbb6f2ef3e6ef7051ea7b922a904L20-L43) [[2]](diffhunk://#diff-e69c32266211b6533ac5a54c04bda80f9cd3bbb6f2ef3e6ef7051ea7b922a904L67-L124)

**Configuration via YAML:**
- Added `features.yaml` under `META-INF/config/default/` to define MyBatis and related features for actuator endpoints, centralizing feature definitions and making them easier to maintain and extend.

**Test Updates:**
- Refactored `MyBatisCloudAutoConfigurationTest` to align with the new feature exposure mechanism, now validating the presence of feature beans by name and checking actuator endpoint responses. [[1]](diffhunk://#diff-7f4e0bc087e37dc686d217fb219faba1d37c61cbb59f74838a8203407a6c1dcbR20-R36) [[2]](diffhunk://#diff-7f4e0bc087e37dc686d217fb219faba1d37c61cbb59f74838a8203407a6c1dcbR46-R85)

**Code Cleanup:**
- Removed unused imports and cleaned up code in `MyBatisBeanDefinitionRegistrar` and `MyBatisConfigurationBeanDefintionRegistrar` for better readability and maintainability. [[1]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL34-L35) [[2]](diffhunk://#diff-f2715d78a054bf83155d34ff2299c41b08e3e997ba4cc5ba628e09532295b32eL48-L65) [[3]](diffhunk://#diff-083d3083daae202313af4d7ae160eeea3e6ce3b0c225c3435cc288ac6eac1fc9L21) [[4]](diffhunk://#diff-083d3083daae202313af4d7ae160eeea3e6ce3b0c225c3435cc288ac6eac1fc9L30)
- Updated Javadoc to use fully qualified class names for clarity.

These changes modernize the configuration and feature exposure in the project, streamline the codebase, and improve maintainability.