### PR TITLE
Fix YAML mapping for ConditionalOnMyBatisAvailable feature

### DIFF
--- a/microsphere-mybatis-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-mybatis-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
@@ -39,4 +39,4 @@ microsphere:
             - io.microsphere.mybatis.executor.ExecutorInterceptor
         named:
           microsphere-mybatis-spring-boot:
-            - ConditionalOnMyBatisAvailable: io.microsphere.mybatis.spring.boot.autoconfigure.condition.ConditionalOnMyBatisAvailable
+            ConditionalOnMyBatisAvailable: io.microsphere.mybatis.spring.boot.autoconfigure.condition.ConditionalOnMyBatisAvailable


### PR DESCRIPTION
This pull request makes a minor formatting adjustment to the `features.yaml` configuration file, ensuring consistent indentation for the `ConditionalOnMyBatisAvailable` entry.