### PR TITLE
Upgrade parent BOM to 0.1.24 and update README version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.13`           |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.13`           |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.14`           |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.14`           |
 
 Then add the specific modules you need.
 

--- a/microsphere-mybatis-core/pom.xml
+++ b/microsphere-mybatis-core/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-java-core</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Mybatis -->

--- a/microsphere-mybatis-parent/pom.xml
+++ b/microsphere-mybatis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.23</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.24</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <mybatis.version>3.5.19</mybatis.version>
         <mybatis-spring.version>2.1.2</mybatis-spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.23</version>
+        <version>0.1.24</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates version numbers across the project to ensure compatibility with the latest dependencies and to reflect a new release. The most important changes are listed below.

**Version Updates:**

* Updated the parent project version in `pom.xml` to `0.1.24` to align with the latest release of `microsphere-spring-cloud-parent`.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-mybatis-parent/pom.xml` to `0.1.24`.
* Updated the documented latest versions for the `main` and `1.x` branches in `README.md` to `0.2.14` and `0.1.14`, respectively.

**Dependency Management:**

* Marked the `microsphere-java-core` dependency as optional in `microsphere-mybatis-core/pom.xml` to clarify its usage and reduce unnecessary transitive dependencies.